### PR TITLE
refatocr(intro): add intro and description time

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -51,7 +51,7 @@ export default defineAppConfig({
     banner: {
       enable: true,
       showClose: true,
-      content: 'Welcome to **Aaron Blog** Renew! 🎉  currently moving old post 🫠',
+      content: 'Welcome to **Aaron Blog**! 🎉  currently Renew and moving old post 🫠',
       to: '/',
       target: '_self',
       border: true,
@@ -65,6 +65,10 @@ export default defineAppConfig({
       }, {
         icon: 'lucide:linkedin',
         to: 'https://www.linkedin.com/in/aaron-shih',
+        target: '_blank',
+      }, {
+        icon: 'lucide:rss',
+        to: '',
         target: '_blank',
       }],
     },

--- a/components/I18nSwitcher.vue
+++ b/components/I18nSwitcher.vue
@@ -26,28 +26,26 @@
 </template>
 
 <script setup lang="ts">
-import type { LocaleMessageObject,Locale } from "vue-i18n"
+import type { Locale, LocaleMessageObject } from 'vue-i18n';
 
 // Type-safe i18n composables
-const { locale, locales, setLocale, t } = useI18n()
-const router = useRouter()
-const route = useRoute()
-const switchLocalePath = useSwitchLocalePath()
+const { locale, locales, setLocale, t } = useI18n();
+const router = useRouter();
+const switchLocalePath = useSwitchLocalePath();
 
 // Type casting and filtering locales
-const availableLocales = computed(() => 
-  (locales.value).filter(l => l.code)
-)
+const availableLocales = computed(() =>
+  (locales.value).filter(l => l.code),
+);
 
 // Locale switching with route preservation
-const switchLocale = (newLocale: Locale) => {
+function switchLocale(newLocale: Locale) {
   // Update locale
-  setLocale(newLocale)
+  setLocale(newLocale);
 
   // Navigate to equivalent page in new locale
   router.push({
-    path: switchLocalePath(newLocale)
-  })
-  
+    path: switchLocalePath(newLocale),
+  });
 }
 </script>

--- a/components/Infos.vue
+++ b/components/Infos.vue
@@ -1,0 +1,38 @@
+<template>
+  <div class="mx-auto max-w-screen-md">
+    <section
+      class="my-2 text-left"
+    >
+      <div class="flex items-center gap-1 text-gray-700 dark:text-white">
+        <span class="iconify  i-lucide:star self-center text-yellow-500" aria-hidden="true" style="font-size:16px;" />
+        <span class="font-semibold">{{ t('createTime') }}:</span>
+        <span>{{ formattedDate }}</span>
+      </div>
+      <div class="flex gap-1 text-gray-700 dark:text-white">
+        <span class="iconify  i-lucide:ambulance self-center text-red-500" aria-hidden="true" style="font-size:16px;" />
+        <span class="font-semibold">{{ t('readTime') }}:</span>
+        <span>~ {{ read }} minutes</span>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+const props = defineProps<{
+  date: string;
+  read: string;
+}>();
+const { t } = useI18n();
+const formattedDate = computed(() => {
+  const dt = new Date(props.date);
+  return dt.toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+});
+</script>

--- a/content/intro.md
+++ b/content/intro.md
@@ -1,8 +1,11 @@
 ---
-title: Intro
-description: 這是一個關於我和我的部落格的介紹
-icon: 'lucide:info'
+title: Intro 前端異聞錄
+description: 與部落格一起成長
+icon: 'lucide:ambulance'
 gitTalk: true
+breadcrumb: false
+date: 2022-10-28 23:45:03
+read: '1'
 authors:
   - name: Aaron Shih
     username: eepson123tw
@@ -11,9 +14,11 @@ authors:
     target: _blank
 ---
 
-3年了...
+寫部落格3年了
 
-征途繼續
+從最初的 `Hexo -> Vuepress -> Vitepress -> Nuxt.js`
+
+征途還要繼續
 
 ## 動機
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,4 +1,6 @@
 {
-	"title": "Language",
-	"subtitle": "Choose your language"
+  "title": "Language",
+  "subtitle": "Choose your language",
+  "createTime": "Create time",
+  "readTime": "Read time"
 }

--- a/locales/i18n.config.ts
+++ b/locales/i18n.config.ts
@@ -1,4 +1,4 @@
 export default defineI18nConfig(() => ({
   legacy: false,
   fallbackLocale: 'en',
-}))
+}));

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -1,4 +1,6 @@
 {
-	"title": "言語",
-	"subtitle": "言語を選択してください"
+  "title": "言語",
+  "subtitle": "言語を選択してください",
+  "createTime": "作成日",
+  "readTime": "読了時間"
 }

--- a/locales/zh-Hant.json
+++ b/locales/zh-Hant.json
@@ -1,4 +1,6 @@
 {
-	"title": "選擇語言",
-	"subtitle": "選擇您的語言"
+  "title": "選擇語言",
+  "subtitle": "選擇您的語言",
+  "createTime": "創建時間",
+  "readTime": "閱讀時間"
 }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -15,7 +15,7 @@ export default defineNuxtConfig({
       { code: 'en', language: 'en-US', name: 'English', file: 'en.json' },
       { code: 'ja', language: 'ja', name: '日本語', file: 'ja.json' },
     ],
-    defaultLocale: 'en',
+    defaultLocale: 'zh-Hant',
     langDir: '../locales',
     strategy: 'no_prefix',
     lazy: true,

--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -25,6 +25,9 @@
         :badges="page?.badges"
         :authors="page?.authors"
       />
+      <ClientOnly fallback-tag="span" fallback="Loading comments...">
+        <Infos v-if="page.date && page.read" :date="page.date" :read="page.read" />
+      </ClientOnly>
 
       <Alert
         v-if="page?.body?.children?.length === 0"
@@ -56,6 +59,8 @@
 </template>
 
 <script setup lang="ts">
+import { Infos } from '#components';
+
 const { page } = useContent();
 const config = useConfig();
 


### PR DESCRIPTION
This pull request includes several changes to improve the configuration, localization, and components of the application. The main changes include updates to the `app.config.ts` and `nuxt.config.ts` files, modifications to localization files, and enhancements to Vue components for better functionality and readability.

Configuration updates:

* [`app.config.ts`](diffhunk://#diff-d51482575c05bfaf700fbd0aff44160e591fc99b684beac4aef55d208a24f42eL54-R54): Updated the banner content and added a new RSS icon link. [[1]](diffhunk://#diff-d51482575c05bfaf700fbd0aff44160e591fc99b684beac4aef55d208a24f42eL54-R54) [[2]](diffhunk://#diff-d51482575c05bfaf700fbd0aff44160e591fc99b684beac4aef55d208a24f42eR69-R72)
* [`nuxt.config.ts`](diffhunk://#diff-5977891bf10802cdd3cde62f0355105a1662e65b02ae4fb404a27bb0f5f53a07L18-R18): Changed the default locale from 'en' to 'zh-Hant'.

Localization enhancements:

* `locales/en.json`, `locales/ja.json`, `locales/zh-Hant.json`: Added new keys for "Create time" and "Read time". [[1]](diffhunk://#diff-c9218bed23f0aeb93d7e1a7d5f6e1345fae20f4b8692b27fb97fd0f37b3d26d7L3-R5) [[2]](diffhunk://#diff-16a8e50d0c47adb7ff9c338e51b98af2e0951b2ff3f41cc9a829c1812b1a9a70L3-R5) [[3]](diffhunk://#diff-904656d546752356f91344e2ed02bf6287852430377fe182871c4e4f87b5ce95L3-R5)
* [`locales/i18n.config.ts`](diffhunk://#diff-c48d72260744484e7dc0e2ee8a16f97c3110c70b7e88e8e0a81475cb1dbd49c5L4-R4): Fixed syntax by adding a closing parenthesis.

Component improvements:

* [`components/I18nSwitcher.vue`](diffhunk://#diff-bec4dd1ce97e9bf3db1001c1bba9a5850f85f588cef07b563892ba379f9aec30L29-R49): Improved code readability by adding semicolons and changing the `switchLocale` function to use the function keyword.
* [`components/Infos.vue`](diffhunk://#diff-e9e4598b18b1cbc73e2ada6963953fd0420dd79d1380aad42de8af04be28ae61R1-R38): Added a new component to display creation time and read time with formatted date and icons.
* `pages/[...slug].vue`: Integrated the new `Infos` component to display additional information about the page. ([pages/[...slug].vueR28-R30](diffhunk://#diff-575d0b4cf7e94b73d7e421f4482180f1832f172bfef28701cf37a48f51d2a17dR28-R30), [pages/[...slug].vueR62-R63](diffhunk://#diff-575d0b4cf7e94b73d7e421f4482180f1832f172bfef28701cf37a48f51d2a17dR62-R63))

Content updates:

* [`content/intro.md`](diffhunk://#diff-cc2c8c6f145b834e82d44ac2f78f4454350dba37a0cfd47d27b58d7e75879741L2-R8): Updated the title, description, and added new metadata fields such as breadcrumb, date, and read time. [[1]](diffhunk://#diff-cc2c8c6f145b834e82d44ac2f78f4454350dba37a0cfd47d27b58d7e75879741L2-R8) [[2]](diffhunk://#diff-cc2c8c6f145b834e82d44ac2f78f4454350dba37a0cfd47d27b58d7e75879741L14-R21)