### PR TITLE
refatocr(smalltalk): refine vite and env file

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -137,7 +137,7 @@ export default defineNuxtConfig({
       brotli: true,
     },
     prerender: {
-      crawlLinks: true,
+      crawlLinks: false,
       failOnError: false,
     },
     watchOptions: {
@@ -225,11 +225,26 @@ export default defineNuxtConfig({
       },
     },
   },
-  compatibilityDate: '2024-10-29',
+  vite: {
+    build: {
+      sourcemap: false,
+      chunkSizeWarningLimit: 4500,
+      rollupOptions: {
+        output: {
+          manualChunks(id) {
+            if (id.includes('node_modules')) {
+              return 'vendor';
+            }
+          },
+        },
+      },
+    },
+  },
   robots: {
     sitemap: 'https://www.aaron-shih.com/sitemap.xml',
   },
   experimental: {
     appManifest: false,
   },
+  compatibilityDate: '2024-10-29',
 });

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "Blog"
   ],
   "scripts": {
-    "build": "cross-env NODE_OPTIONS='--max-old-space-size=16384' nuxt build",
+    "build": "cross-env NODE_OPTIONS='--max-old-space-size=16384' SKIP_RSS=true nuxt build",
+    "build:rss": "cross-env NODE_OPTIONS='--max-old-space-size=16384' nuxt build",
     "dev": "nuxt dev",
     "generate": "nuxt generate",
     "preview": "nuxt preview",


### PR DESCRIPTION
This pull request includes several changes to the `nuxt.config.ts` and `package.json` files to improve the build configuration and control the behavior of the prerendering process.

Changes to `nuxt.config.ts`:

* Disabled link crawling during prerendering by setting `crawlLinks` to `false` in the `prerender` configuration.
* Added a `vite` configuration block to customize the build process, including disabling sourcemaps, setting a chunk size warning limit, and defining manual chunks for Rollup.

Changes to `package.json`:

* Modified the `build` script to include an environment variable `SKIP_RSS` and added a new script `build:rss` for building with RSS support.