### PR TITLE
refatocr(og): add og image component

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -8,12 +8,6 @@ import { parseStringPromise } from 'xml2js';
 export default defineNuxtConfig({
   devtools: { enabled: false },
   extends: ['shadcn-docs-nuxt'],
-  content: {
-    highlight: {
-      theme: 'github-light',
-      preload: ['dockerfile', 'mermaid', 'yaml', 'toml'],
-    },
-  },
   i18n: {
     vueI18n: './locales/i18n.config.ts',
     locales: [
@@ -26,13 +20,24 @@ export default defineNuxtConfig({
     strategy: 'no_prefix',
     lazy: true,
   },
-  modules: ['@nuxtjs/i18n', '@nuxt/image', '@nuxtjs/robots', '@nuxtjs/sitemap'],
+  modules: ['nuxt-og-image', '@nuxtjs/i18n', '@nuxt/image', '@nuxtjs/robots', '@nuxtjs/sitemap'],
   components: {
     dirs: [
       {
         path: './components',
         ignore: ['**/*.ts'],
       },
+    ],
+  },
+  content: {
+    highlight: {
+      theme: 'github-light',
+      preload: ['dockerfile', 'mermaid', 'yaml', 'toml'],
+    },
+  },
+  ogImage: {
+    fonts: [
+      'Noto+Sans+SC:400',
     ],
   },
   app: {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "eslint-plugin-tailwindcss": "^3.18.0",
     "gitalk": "^1.8.0",
     "nuxt": "^3.15.2",
+    "nuxt-og-image": "^4.1.2",
     "posthog-js": "^1.210.2",
     "rss": "^1.2.2",
     "shadcn-docs-nuxt": "^0.8.11",

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,0 +1,33 @@
+<template>
+  <div
+    class="px-4 py-6 md:px-8"
+    :class="[config.main.padded && 'container']"
+  >
+    <ContentRenderer
+      :key="page._id"
+      :value="page"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+// import { BlogPost } from '#components';
+
+const { page } = useContent();
+const config = useConfig();
+
+useSeoMeta({
+  title: `${page.value?.title ?? '404'} - ${config.value.site.name}`,
+  ogTitle: page.value?.title,
+  description: page.value?.description,
+  ogDescription: page.value?.description,
+  ogImage: config.value.site.ogImage,
+  twitterCard: 'summary_large_image',
+});
+
+defineOgImageComponent('BlogPost', {
+  title: page.value?.title,
+  description: page.value?.description,
+  colorMode: 'light',
+});
+</script>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       nuxt:
         specifier: ^3.15.2
         version: 3.15.2(@parcel/watcher@2.5.0)(@types/node@22.10.7)(db0@0.2.1)(encoding@0.1.13)(eslint@9.19.0(jiti@2.4.2))(ioredis@5.4.2)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.31.0)(terser@5.37.0)(typescript@5.7.3)(vite@6.0.11(@types/node@22.10.7)(jiti@2.4.2)(terser@5.37.0)(yaml@2.7.0))(xml2js@0.6.2)(yaml@2.7.0)
+      nuxt-og-image:
+        specifier: ^4.1.2
+        version: 4.1.2(magicast@0.3.5)(rollup@4.31.0)(vite@6.0.11(@types/node@22.10.7)(jiti@2.4.2)(terser@5.37.0)(yaml@2.7.0))(vue@3.5.13(typescript@5.7.3))
       posthog-js:
         specifier: ^1.210.2
         version: 1.210.2


### PR DESCRIPTION
This pull request includes several changes to the `nuxt.config.ts` file, the addition of a new module, and updates to the `pages/index.vue` and `package.json` files. The most important changes involve reordering and adding modules, reconfiguring content highlighting, and integrating a new Open Graph image feature.

### Changes to `nuxt.config.ts`:

* Reordered and added the `nuxt-og-image` module to the `modules` array.
* Re-added the `content` configuration for syntax highlighting with the `github-light` theme and specified file types for preloading.
* Added the `ogImage` configuration with specified fonts for Open Graph images.

### Changes to `package.json`:

* Added the `nuxt-og-image` dependency with version `^4.1.2`.

### Changes to `pages/index.vue`:

* Added a new template and script setup to render content and configure SEO meta tags, including Open Graph image settings.

### Changes to `pnpm-lock.yaml`:

* Added lockfile entries for the `nuxt-og-image` module.