### PR TITLE
feat(rss.xml): reformat xml logic

### DIFF
--- a/components/Infos.vue
+++ b/components/Infos.vue
@@ -6,7 +6,7 @@
       <div class="flex items-center gap-1 text-gray-700 dark:text-white">
         <span class="iconify  i-lucide:star self-center text-yellow-500" aria-hidden="true" style="font-size:16px;" />
         <span class="font-semibold">{{ t('createTime') }}:</span>
-        <span>{{ formattedDate }}</span>
+        <span data-create-time="formattedDate">{{ formattedDate }}</span>
       </div>
       <div class="flex gap-1 text-gray-700 dark:text-white">
         <span class="iconify  i-lucide:ambulance self-center text-red-500" aria-hidden="true" style="font-size:16px;" />

--- a/utils/feed.ts
+++ b/utils/feed.ts
@@ -1,0 +1,105 @@
+import * as cheerio from 'cheerio';
+import RSS from 'rss';
+
+interface UrlEntry {
+  loc?: string[];
+  lastmod?: string[];
+}
+
+interface FeedItem {
+  title: string;
+  description: string;
+  url: string;
+  date: string;
+}
+
+// utils/dateParser.ts
+export function parseAndFormatDate(dateString: string): string | null {
+  if (!dateString)
+    return null;
+
+  // Handle date string like "January 19, 2025 at 03:32 PM"
+  const dateRegex = /(\w+ \d+, \d+) at (\d+):(\d+) (AM|PM)/;
+  const match = dateString.match(dateRegex);
+
+  if (match) {
+    const [_, datePart, hours, minutes, period] = match;
+    let hour = Number.parseInt(hours);
+    if (period === 'PM' && hour !== 12) {
+      hour += 12;
+    } else if (period === 'AM' && hour === 12) {
+      hour = 0;
+    }
+    const date = new Date(`${datePart} ${hour.toString().padStart(2, '0')}:${minutes}`);
+    return date.toUTCString();
+  }
+
+  // Try parsing ISO 8601 format
+  const isoDate = new Date(dateString);
+  if (!Number.isNaN(isoDate.getTime())) {
+    return isoDate.toUTCString();
+  }
+
+  return null;
+}
+
+export async function genFeed(urlEntries: UrlEntry[]): Promise<string> {
+  const feed = new RSS({
+    title: 'My Website RSS',
+    description: 'Latest updates from my site',
+    feed_url: 'https://www.aaron-shih.com/rss.xml',
+    site_url: 'https://www.aaron-shih.com',
+    language: 'en',
+  });
+
+  const feedEntries: FeedItem[] = [];
+
+  for (const entry of urlEntries) {
+    const loc = entry.loc?.[0];
+    if (!loc)
+      continue;
+
+    try {
+      const pageResp = await fetch(loc, { signal: AbortSignal.timeout(10_000) });
+      if (!pageResp.ok)
+        continue;
+
+      const html = await pageResp.text();
+      const $ = cheerio.load(html);
+
+      // Get title
+      const pageTitle = $('title').text()?.trim() || loc;
+
+      // Get description
+      const pageDescription = $('meta[name="description"]').attr('content')?.trim() || `Page URL: ${loc}`;
+
+      // Get creation date using data attribute
+      const creationDate = $('span[data-create-time]').attr('data-create-time') as string;
+      let pubDate = parseAndFormatDate(creationDate);
+
+      // Fallback to lastmod or meta modified time if creation date not found
+      if (!pubDate) {
+        const lastmod = entry.lastmod?.[0] || $('meta[property="article:modified_time"]').attr('content') as string;
+        pubDate = parseAndFormatDate(lastmod);
+      }
+
+      feedEntries.push({
+        title: pageTitle,
+        description: pageDescription,
+        url: loc,
+        date: pubDate || new Date().toUTCString(),
+      });
+    } catch (e) {
+      console.error(`Failed to fetch or parse ${loc}`, e);
+    }
+  }
+
+  // Sort entries by date, newest first
+  feedEntries.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+
+  // Add sorted entries to feed
+  for (const entry of feedEntries)
+    feed.item(entry);
+
+  return feed.xml({ indent: true });
+}


### PR DESCRIPTION
This pull request refactors the RSS feed generation process by moving the logic to a new utility file and simplifying the `nuxt.config.ts` configuration. Additionally, it includes a small change to the `components/Infos.vue` file to add a data attribute for the creation time.

Refactoring and simplification:

* [`nuxt.config.ts`](diffhunk://#diff-5977891bf10802cdd3cde62f0355105a1662e65b02ae4fb404a27bb0f5f53a07L4-R5): Removed inline RSS feed generation logic and replaced it with a call to `genFeed` from the new `utils/feed.ts` file. This change also includes removing unnecessary imports and comments. [[1]](diffhunk://#diff-5977891bf10802cdd3cde62f0355105a1662e65b02ae4fb404a27bb0f5f53a07L4-R5) [[2]](diffhunk://#diff-5977891bf10802cdd3cde62f0355105a1662e65b02ae4fb404a27bb0f5f53a07L157-R174)

New utility function:

* [`utils/feed.ts`](diffhunk://#diff-9d9986f0c678ec7090813952d971cbe9b7e70df1ec6724a80c67733b219b4ab2R1-R105): Added a new utility function `genFeed` to handle RSS feed generation. This function fetches pages, extracts metadata, and generates the RSS XML. It also includes a helper function `parseAndFormatDate` for date parsing and formatting.

Minor change:

* [`components/Infos.vue`](diffhunk://#diff-e9e4598b18b1cbc73e2ada6963953fd0420dd79d1380aad42de8af04be28ae61L9-R9): Added a `data-create-time` attribute to the span displaying the formatted creation date.