### PR TITLE
feat(rss): fix rss time and useHead to inject meta

### DIFF
--- a/components/Infos.vue
+++ b/components/Infos.vue
@@ -6,7 +6,7 @@
       <div class="flex items-center gap-1 text-gray-700 dark:text-white">
         <span class="iconify  i-lucide:star self-center text-yellow-500" aria-hidden="true" style="font-size:16px;" />
         <span class="font-semibold">{{ t('createTime') }}:</span>
-        <span data-create-time="formattedDate">{{ formattedDate }}</span>
+        <span>{{ formattedDate }}</span>
       </div>
       <div class="flex gap-1 text-gray-700 dark:text-white">
         <span class="iconify  i-lucide:ambulance self-center text-red-500" aria-hidden="true" style="font-size:16px;" />

--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -73,6 +73,10 @@ useSeoMeta({
   twitterCard: 'summary_large_image',
 });
 
+useHead({
+  meta: [{ property: 'article:modified_time', content: `${page.value?.date}` }],
+});
+
 defineOgImageComponent(config.value.site.ogImageComponent, {
   title: page.value?.title,
   description: page.value?.description,

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -23,6 +23,11 @@ useSeoMeta({
   ogDescription: page.value?.description,
   ogImage: config.value.site.ogImage,
   twitterCard: 'summary_large_image',
+
+});
+
+useHead({
+  meta: [{ property: 'article:modified_time', content: `${page.value?.date}` }],
 });
 
 defineOgImageComponent('BlogPost', {

--- a/utils/feed.ts
+++ b/utils/feed.ts
@@ -73,15 +73,8 @@ export async function genFeed(urlEntries: UrlEntry[]): Promise<string> {
       // Get description
       const pageDescription = $('meta[name="description"]').attr('content')?.trim() || `Page URL: ${loc}`;
 
-      // Get creation date using data attribute
-      const creationDate = $('span[data-create-time]').attr('data-create-time') as string;
-      let pubDate = parseAndFormatDate(creationDate);
-
-      // Fallback to lastmod or meta modified time if creation date not found
-      if (!pubDate) {
-        const lastmod = entry.lastmod?.[0] || $('meta[property="article:modified_time"]').attr('content') as string;
-        pubDate = parseAndFormatDate(lastmod);
-      }
+      const lastmod = entry.lastmod?.[0] || $('meta[property="article:modified_time"]').attr('content') as string;
+      const pubDate = parseAndFormatDate(lastmod);
 
       feedEntries.push({
         title: pageTitle,


### PR DESCRIPTION
This pull request includes several changes aimed at improving the handling of metadata and simplifying the codebase. The most important changes involve updates to the `Infos.vue` component, the `useSeoMeta` function in two different files, and the `genFeed` function in `utils/feed.ts`.

Improvements to metadata handling:

* `pages/[...slug].vue`: Added a `useHead` call to include the `article:modified_time` meta tag for better SEO. ([pages/[...slug].vueR76-R79](diffhunk://#diff-575d0b4cf7e94b73d7e421f4482180f1832f172bfef28701cf37a48f51d2a17dR76-R79))
* [`pages/index.vue`](diffhunk://#diff-02281a80fab758cb4e8e8359b222a8a5afeaa9d5a7ba858f15d852f1f8969ecfR26-R30): Added a `useHead` call to include the `article:modified_time` meta tag for better SEO.

Codebase simplification:

* [`components/Infos.vue`](diffhunk://#diff-e9e4598b18b1cbc73e2ada6963953fd0420dd79d1380aad42de8af04be28ae61L9-R9): Removed the `data-create-time` attribute from the `span` element displaying `formattedDate`.
* [`utils/feed.ts`](diffhunk://#diff-9d9986f0c678ec7090813952d971cbe9b7e70df1ec6724a80c67733b219b4ab2L76-R77): Simplified the `genFeed` function by removing the fallback logic for the creation date and using the `lastmod` date directly.