### PR TITLE
feat(sitemap): make sitemap to default view

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -207,6 +207,7 @@ export default defineNuxtConfig({
     sitemap: 'https://www.aaron-shih.com/sitemap.xml',
   },
   sitemap: {
+    xsl: false,
     defaults: {
       changefreq: 'daily',
       priority: 0.8,


### PR DESCRIPTION
This pull request includes a small change to the `nuxt.config.ts` file. The change disables the XSL transformation for the sitemap configuration.

* [`nuxt.config.ts`](diffhunk://#diff-5977891bf10802cdd3cde62f0355105a1662e65b02ae4fb404a27bb0f5f53a07R210): Added `xsl: false` to the sitemap configuration.